### PR TITLE
Add simple import rewrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
       - uses: haskell/actions/setup@v1
         with:
           ghc-version: '8.10.4' # Exact version of ghc to use

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: true
       - uses: haskell/actions/setup@v1
         with:
-          ghc-version: '8.10.4'
+          ghc-version: "8.10.4"
       - name: Freeze
         run: |
           cabal freeze
@@ -31,4 +31,4 @@ jobs:
         if: steps.cache-primes.outputs.cache-hit != 'true'
         run: cabal build all --only-dependencies
       - name: Build and test project
-        run: cabal build all && cabal test all
+        run: cabal build all && cabal test all --test-options=--color

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
         uses: actions/cache@v2
         with:
-          path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+          path: |
+            ~/.cabal/store
+            dist-newstyle
           key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
       - name: Build dependencies
         if: steps.cache-primes.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,7 @@ jobs:
       - name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
         uses: actions/cache@v2
         with:
-          path: |
-            ~/.cabal/store
-            dist-newstyle
+          path: ~/.cabal/store
           key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
       - name: Build dependencies
         if: steps.cache-primes.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+  pull_request:
+    branches: [main]
+name: build
+jobs:
+  ci:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haskell/actions/setup@v1
+        with:
+          ghc-version: '8.10.4' # Exact version of ghc to use
+          enable-stack: true
+          stack-version: 'latest'
+      - run: stack test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches: [main]
 name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,17 @@ jobs:
           submodules: true
       - uses: haskell/actions/setup@v1
         with:
-          ghc-version: '8.10.4' # Exact version of ghc to use
-          enable-stack: true
-          stack-version: 'latest'
-      - run: stack test
+          ghc-version: '8.10.4'
+      - name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}
+      - name: Build dependencies
+        if: steps.cache-primes.outputs.cache-hit != 'true'
+        run: cabal build --only-dependencies
+      - name: Build and test project
+        run: cabal test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,16 @@ jobs:
       - uses: haskell/actions/setup@v1
         with:
           ghc-version: '8.10.4'
+      - name: Freeze
+        run: |
+          cabal freeze
       - name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
         uses: actions/cache@v2
         with:
-          path: |
-            ~/.cabal/packages
-            ~/.cabal/store
-            dist-newstyle
-          key: key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('purescript-cst-rewrite.cabal') }}
+          path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
       - name: Build dependencies
         if: steps.cache-primes.outputs.cache-hit != 'true'
-        run: cabal build --only-dependencies
+        run: cabal build all --only-dependencies
       - name: Build and test project
-        run: cabal test
+        run: cabal build all && cabal test all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ jobs:
   ci:
     name: Run tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc: ["8.10.4"]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -23,7 +26,7 @@ jobs:
             ~/.cabal/packages
             ~/.cabal/store
             dist-newstyle
-          key: ${{ runner.os }}-${{ matrix.ghc }}
+          key: key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('purescript-cst-rewrite.cabal') }}
       - name: Build dependencies
         if: steps.cache-primes.outputs.cache-hit != 'true'
         run: cabal build --only-dependencies

--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# purescript-cst-rewrite
+# `purescript-cst-rewrite`
+
+ScalaFix for PureScript!
+
+[ScalaFix] is a tool for automatically rewriting Scala code based on
+rules. These rules can be used for a few things:
+
+- organizing imports based on some package name matching rules
+- removing unused code
+- changing import paths after an upgrade
+- replacing deprecated method calls with non-deprecated calls
+
+Pretty complicated automatic refactors are possible! For example,
+`cats-effect` included Scalafix rules for the [`cats-effect` 3.0 release]
+which overhauled the whole effect typeclass hierarchy. Users can apply
+the rule and skip to the non-boring parts of the upgrade. It's neat!
+
+I propose that a similar tool would be valuable for PureScript. The design
+goals for this tool are:
+
+- a simple CLI -- users shouldn't need to know about a lot of options, just locations
+  of the rules and source code they want to use
+- avoid reinventing the wheel -- there are already parsers and printers for PureScript
+  CSTs, and those should be reused
+- avoid hand-rolling new data formats -- developers everywhere use `git`, so borrow the
+  `git` diff syntax with a tiny modification to keep things obvious
+
+Design non-goals are:
+
+- ensuring that resulting code compiles -- this might not always be possible, for example,
+  if replacing a deprecated function call requires additional parameters. It also might not
+  be desirable, for example, if filling in a `Nothing` where `Maybes` are expected changes
+  behavior. The goal is just to automate the boring part, so that users can get to the
+  point where they have to make choices more easily.
+- supporting every kind of rewrite imaginable _right now_. This is very proof-of-concept for
+  now and I'm not going to go full steam ahead until there's some confirmation that this is
+  a useful tool. The first type of rewrite I'll support is module renames, since they're an
+  area where the existing language server tooling isn't super helpful.
+
+With those in mind, an example invocation might look like this:
+
+Suppose you have a PureScript project with code under `src/` and you've upgraded a library
+version. The library author would publish a rule like:
+
+```diff
+# module rename
+--- from
+-import My.Package.Path.Foo
++++ to
++import My.Package.Foo
+```
+
+When upgrading, you would run:
+
+```bash
+purescript-cst-rewrite https://github.com/organization/library/tree/v2.0.0/rules/v2.0.0.diff src/
+```
+
+And all of the imports would be rewritten for you ✨
+
+[ScalaFix]: https://scalacenter.github.io/scalafix/
+[`cats-effect` 3.0 release]: https://github.com/typelevel/cats-effect/tree/series/3.x/scalafix/v3_0_0/input/src/main/scala/fix

--- a/README.md
+++ b/README.md
@@ -31,9 +31,8 @@ Design non-goals are:
   if replacing a deprecated function call requires additional parameters. It also might not
   be desirable, for example, if filling in a `Nothing` where `Maybes` are expected changes
   behavior. The goal is just to automate the boring part, so that users can get to the
-  point where they have to make choices more easily.
-- supporting every kind of rewrite imaginable _right now_. This is very proof-of-concept for
-  now and I'm not going to go full steam ahead until there's some confirmation that this is
+  point where they have to make choices more quickly.
+- supporting every kind of rewrite imaginable _right now_. This is very proof-of-concept and I'm not going to go full steam ahead until there's some confirmation that this is
   a useful tool. The first type of rewrite I'll support is module renames, since they're an
   area where the existing language server tooling isn't super helpful.
 
@@ -57,6 +56,12 @@ purescript-cst-rewrite https://github.com/organization/library/tree/v2.0.0/rules
 ```
 
 And all of the imports would be rewritten for you ✨
+
+The short-term road map is:
+
+- [x] automatic module renames
+- [ ] add the CLI
+- [ ] rename imports (e.g. `s/import Foo (bar)/import Foo (baz)/`)
 
 [ScalaFix]: https://scalacenter.github.io/scalafix/
 [`cats-effect` 3.0 release]: https://github.com/typelevel/cats-effect/tree/series/3.x/scalafix/v3_0_0/input/src/main/scala/fix

--- a/purescript-cst-rewrite.cabal
+++ b/purescript-cst-rewrite.cabal
@@ -16,9 +16,13 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Data.CSTRewrite
+                     , Data.CSTRewrite.Parser
                      , Data.CSTRewrite.Rule
   build-depends:       base >= 4.7 && < 5
+                     , purescript-ast
                      , purescript-cst
+                     , parsec
+                     , text
   default-language:    Haskell2010
 
 test-suite cst-rewrite-test
@@ -28,6 +32,7 @@ test-suite cst-rewrite-test
   build-depends:       base
                      , purescript-cst-rewrite
                      , purescript-cst
+                     , parsec
                      , text
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010

--- a/purescript-cst-rewrite.cabal
+++ b/purescript-cst-rewrite.cabal
@@ -15,7 +15,8 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Lib
+  exposed-modules:     Data.CSTRewrite
+                     , Data.CSTRewrite.Rule
   build-depends:       base >= 4.7 && < 5
                      , purescript-cst
   default-language:    Haskell2010
@@ -26,6 +27,8 @@ test-suite cst-rewrite-test
   main-is:             Main.hs
   build-depends:       base
                      , purescript-cst-rewrite
+                     , purescript-cst
+                     , text
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/purescript-cst-rewrite.cabal
+++ b/purescript-cst-rewrite.cabal
@@ -30,7 +30,9 @@ test-suite cst-rewrite-test
   hs-source-dirs:      test
   main-is:             Main.hs
   build-depends:       base
+                     , hspec
                      , purescript-cst-rewrite
+                     , purescript-ast
                      , purescript-cst
                      , parsec
                      , text

--- a/src/Data/CSTRewrite.hs
+++ b/src/Data/CSTRewrite.hs
@@ -1,9 +1,9 @@
 module Data.CSTRewrite (rewrite) where
 
-import Data.CSTRewrite.Rule (ImportRule (from, to), ImportRules, Rules (importRules))
+import Data.CSTRewrite.Rule (ImportRule (from, to), ImportRules, ModuleRenameRules, Rules (importRules, moduleRenameRules), fromModuleName, toModuleName)
 import Data.Foldable (fold)
-import Debug.Trace (trace)
 import qualified Language.PureScript.CST.Types as PS
+import qualified Language.PureScript.Names as N
 
 -- The default monoid for functions relies on a Monoid for the return type
 -- and is implemented as
@@ -20,23 +20,21 @@ instance Semigroup (Endo a) where
 instance Monoid (Endo a) where
   mempty = Endo id
 
-replace :: Eq a => a -> a -> [a] -> [a]
-replace from to [] = []
-replace from to (x : xs) =
-  if x == from then to : replace from to xs else x : replace from to xs
-
-mkReplacer :: Eq e => ImportRules e -> Endo [PS.ImportDecl e]
-mkReplacer rules =
-  let froms = from <$> rules
-      tos = to <$> rules
-      partials = Endo <$> zipWith replace froms tos
+mkModuleNameReplacer :: Eq e => ModuleRenameRules e -> Endo (PS.ImportDecl e)
+mkModuleNameReplacer rules =
+  let froms = fromModuleName <$> rules
+      tos = toModuleName <$> rules
+      partials = Endo <$> zipWith renameModule froms tos
    in fold partials
+
+renameModule :: Eq e => N.ModuleName -> N.ModuleName -> PS.ImportDecl e -> PS.ImportDecl e
+renameModule from to decl =
+  let startImp = PS.impModule decl
+   in if (PS.nameValue startImp == from) then decl {PS.impModule = startImp {PS.nameValue = to}} else decl
 
 rewrite :: (Eq e, Show e) => Rules e -> PS.Module e -> PS.Module e
 rewrite rules mod =
-  let irs = importRules rules
-      replacer = mkReplacer irs
-      replaced = unEndo replacer $ PS.modImports mod
-   in trace ("Replaced: " ++ show replaced) $
-        trace ("Rules: " ++ show irs) $
-          mod {PS.modImports = unEndo replacer $ PS.modImports mod}
+  let moduleRenames = moduleRenameRules rules
+      replacer = mkModuleNameReplacer moduleRenames
+      replaced = unEndo replacer <$> PS.modImports mod
+   in mod {PS.modImports = replaced}

--- a/src/Data/CSTRewrite.hs
+++ b/src/Data/CSTRewrite.hs
@@ -5,23 +5,38 @@ import Data.Foldable (fold)
 import Debug.Trace (trace)
 import qualified Language.PureScript.CST.Types as PS
 
+-- The default monoid for functions relies on a Monoid for the return type
+-- and is implemented as
+-- @since 2.01
+-- instance Monoid b => Monoid (a -> b) where
+--   mempty _ = mempty
+-- We want a new behavior, where we form a monoid under composition instead,
+-- since we know that the functions are endofunctors
+newtype Endo a = Endo {unEndo :: a -> a}
+
+instance Semigroup (Endo a) where
+  (<>) (Endo f) (Endo g) = Endo (f . g)
+
+instance Monoid (Endo a) where
+  mempty = Endo id
+
 replace :: Eq a => a -> a -> [a] -> [a]
 replace from to [] = []
 replace from to (x : xs) =
   if x == from then to : replace from to xs else x : replace from to xs
 
-mkReplacer :: Eq e => ImportRules e -> [PS.ImportDecl e] -> [PS.ImportDecl e]
+mkReplacer :: Eq e => ImportRules e -> Endo [PS.ImportDecl e]
 mkReplacer rules =
   let froms = from <$> rules
       tos = to <$> rules
-      partials = zipWith replace froms tos
+      partials = Endo <$> zipWith replace froms tos
    in fold partials
 
 rewrite :: (Eq e, Show e) => Rules e -> PS.Module e -> PS.Module e
 rewrite rules mod =
   let irs = importRules rules
       replacer = mkReplacer irs
-      replaced = replacer $ PS.modImports mod
+      replaced = unEndo replacer $ PS.modImports mod
    in trace ("Replaced: " ++ show replaced) $
         trace ("Rules: " ++ show irs) $
-          mod {PS.modImports = replacer $ PS.modImports mod}
+          mod {PS.modImports = unEndo replacer $ PS.modImports mod}

--- a/src/Data/CSTRewrite.hs
+++ b/src/Data/CSTRewrite.hs
@@ -1,6 +1,6 @@
 module Data.CSTRewrite (rewrite) where
 
-import Data.CSTRewrite.Rule (ImportRule (from, to), ImportRules, ModuleRenameRules, Rules (importRules, moduleRenameRules), fromModuleName, toModuleName)
+import Data.CSTRewrite.Rule (ModuleRenameRules, Rules, fromModuleName, moduleRenameRules, toModuleName)
 import Data.Foldable (fold)
 import qualified Language.PureScript.CST.Types as PS
 import qualified Language.PureScript.Names as N

--- a/src/Data/CSTRewrite.hs
+++ b/src/Data/CSTRewrite.hs
@@ -1,6 +1,7 @@
 module Data.CSTRewrite where
 
+import Data.CSTRewrite.Rule ( Rules )
 import qualified Language.PureScript.CST.Types as PS
 
-rewrite :: PS.Module e -> PS.Module e
-rewrite = undefined
+rewrite :: Rules e -> PS.Module e -> PS.Module e
+rewrite rules mod = undefined

--- a/src/Data/CSTRewrite.hs
+++ b/src/Data/CSTRewrite.hs
@@ -1,7 +1,27 @@
-module Data.CSTRewrite where
+module Data.CSTRewrite (rewrite) where
 
-import Data.CSTRewrite.Rule ( Rules )
+import Data.CSTRewrite.Rule (ImportRule (from, to), ImportRules, Rules (importRules))
+import Data.Foldable (fold)
+import Debug.Trace (trace)
 import qualified Language.PureScript.CST.Types as PS
 
-rewrite :: Rules e -> PS.Module e -> PS.Module e
-rewrite rules mod = undefined
+replace :: Eq a => a -> a -> [a] -> [a]
+replace from to [] = []
+replace from to (x : xs) =
+  if x == from then to : replace from to xs else x : replace from to xs
+
+mkReplacer :: Eq e => ImportRules e -> [PS.ImportDecl e] -> [PS.ImportDecl e]
+mkReplacer rules =
+  let froms = from <$> rules
+      tos = to <$> rules
+      partials = zipWith replace froms tos
+   in fold partials
+
+rewrite :: (Eq e, Show e) => Rules e -> PS.Module e -> PS.Module e
+rewrite rules mod =
+  let irs = importRules rules
+      replacer = mkReplacer irs
+      replaced = replacer $ PS.modImports mod
+   in trace ("Replaced: " ++ show replaced) $
+        trace ("Rules: " ++ show irs) $
+          mod {PS.modImports = replacer $ PS.modImports mod}

--- a/src/Data/CSTRewrite/Parser.hs
+++ b/src/Data/CSTRewrite/Parser.hs
@@ -34,8 +34,8 @@ parseModuleRename = do
   endOfLine
   char '+'
   newImportLine <- manyTill anyChar (() <$ try endOfLine <|> eof)
-  let (_, oldImportDeclResult) = PS.runParser (parserState $ PS.lex (pack newImportLine)) PS.parseImportDeclP
-  let (_, newImportDeclResult) = PS.runParser (parserState $ PS.lex (pack oldImportLine)) PS.parseImportDeclP
+  let (_, oldImportDeclResult) = PS.runParser (parserState $ PS.lex (pack oldImportLine)) PS.parseImportDeclP
+  let (_, newImportDeclResult) = PS.runParser (parserState $ PS.lex (pack newImportLine)) PS.parseImportDeclP
   case (oldImportDeclResult, newImportDeclResult) of
     (Right old, Right new) ->
       pure $ ModuleRenameRule (PS.nameValue . PS.impModule $ old) (PS.nameValue . PS.impModule $ new)

--- a/src/Data/CSTRewrite/Parser.hs
+++ b/src/Data/CSTRewrite/Parser.hs
@@ -1,0 +1,47 @@
+module Data.CSTRewrite.Parser where
+
+import Data.CSTRewrite.Rule (ModuleRenameRule (ModuleRenameRule))
+import Data.Functor.Identity (Identity)
+import Data.Text (Text, pack)
+import qualified Language.PureScript.CST.Lexer as PS
+import qualified Language.PureScript.CST.Monad as PS
+import qualified Language.PureScript.CST.Parser as PS
+import qualified Language.PureScript.CST.Types as PS
+import Text.Parsec (ParseError, ParsecT, anyChar, endBy, endOfLine, eof, manyTill, parserFail, try, (<|>))
+import Text.ParserCombinators.Parsec.Char (char, string)
+
+type RuleParser = ParsecT Text () Identity
+
+-- what's the game? re-use the existing parser for ImportDecls
+-- to parse a git diff-style document showing the old import and
+-- the new import.
+-- the idea here is that users will get to specify the old and
+-- new imports in the familiar purescript style, and I won't have
+-- to invent a format for the planned change.
+
+parserState :: [PS.LexResult] -> PS.ParserState
+parserState lexed = PS.ParserState lexed [] []
+
+parseModuleRename :: RuleParser (ModuleRenameRule ())
+parseModuleRename = do
+  string "# module rename"
+  endOfLine
+  string "--- from"
+  endOfLine
+  char '-'
+  oldImportLine <- manyTill anyChar endOfLine
+  string "+++ to"
+  endOfLine
+  char '+'
+  newImportLine <- manyTill anyChar (() <$ try endOfLine <|> eof)
+  let (_, oldImportDeclResult) = PS.runParser (parserState $ PS.lex (pack newImportLine)) PS.parseImportDeclP
+  let (_, newImportDeclResult) = PS.runParser (parserState $ PS.lex (pack oldImportLine)) PS.parseImportDeclP
+  case (oldImportDeclResult, newImportDeclResult) of
+    (Right old, Right new) ->
+      pure $ ModuleRenameRule (PS.nameValue . PS.impModule $ old) (PS.nameValue . PS.impModule $ new)
+    (Left old, Left new) ->
+      parserFail $ show old ++ show new
+    (Left old, _) ->
+      parserFail $ show old
+    (_, Left new) ->
+      parserFail $ show new

--- a/src/Data/CSTRewrite/Rule.hs
+++ b/src/Data/CSTRewrite/Rule.hs
@@ -1,12 +1,19 @@
 module Data.CSTRewrite.Rule where
 
-import Language.PureScript.CST.Types ( ImportDecl )
+import Language.PureScript.CST.Types (ImportDecl)
+import qualified Language.PureScript.Names as N
 
-data ImportRule e
-  = RewriteImport { from :: ImportDecl e, to :: ImportDecl e}
+data ImportRule e = RewriteImport {from :: ImportDecl e, to :: ImportDecl e} deriving (Eq, Show)
 
-type ImportRules e
-  = [ImportRule e]
+data ModuleRenameRule e = ModuleRenameRule {fromModuleName :: N.ModuleName, toModuleName :: N.ModuleName} deriving (Eq, Show)
 
-data Rules e
-  = Rules { importRules :: ImportRules e }
+type ModuleRenameRules e =
+  [ModuleRenameRule e]
+
+type ImportRules e =
+  [ImportRule e]
+
+data Rules e = Rules
+  { importRules :: ImportRules e,
+    moduleRenameRules :: ModuleRenameRules e
+  }

--- a/src/Data/CSTRewrite/Rule.hs
+++ b/src/Data/CSTRewrite/Rule.hs
@@ -3,17 +3,11 @@ module Data.CSTRewrite.Rule where
 import Language.PureScript.CST.Types (ImportDecl)
 import qualified Language.PureScript.Names as N
 
-data ImportRule e = RewriteImport {from :: ImportDecl e, to :: ImportDecl e} deriving (Eq, Show)
-
 data ModuleRenameRule e = ModuleRenameRule {fromModuleName :: N.ModuleName, toModuleName :: N.ModuleName} deriving (Eq, Show)
 
 type ModuleRenameRules e =
   [ModuleRenameRule e]
 
-type ImportRules e =
-  [ImportRule e]
-
 data Rules e = Rules
-  { importRules :: ImportRules e,
-    moduleRenameRules :: ModuleRenameRules e
+  { moduleRenameRules :: ModuleRenameRules e
   }

--- a/src/Data/CSTRewrite/Rule.hs
+++ b/src/Data/CSTRewrite/Rule.hs
@@ -1,9 +1,9 @@
 module Data.CSTRewrite.Rule where
 
-import qualified Language.PureScript.CST.Types as PS
+import Language.PureScript.CST.Types ( ImportDecl )
 
 data ImportRule e
-  = RewriteImport { from :: PS.ImportDecl e, to :: PS.ImportDecl e}
+  = RewriteImport { from :: ImportDecl e, to :: ImportDecl e}
 
 type ImportRules e
   = [ImportRule e]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -10,7 +10,6 @@ import qualified Data.Text.IO as T
 import GHC.IO.Exception (ExitCode (..))
 import qualified Language.PureScript.CST.Lexer as PS
 import qualified Language.PureScript.CST.Parser as PS
-import qualified Language.PureScript.CST.Print as PS
 import qualified Language.PureScript.CST.Types as PS
 import Language.PureScript.Names as N
 import System.Exit (exitWith)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -30,7 +30,6 @@ testImportRewrite = do
   inModuleText <- T.readFile "./test/data/example.purs"
   let lexed = PS.lex inModuleText
   let parsedModule = PS.parseModule lexed
-  print . show $ PS.resPartial <$> parsedModule
   inRuleText <- T.readFile "./test/data/module-rename-single.diff"
   let parsedRule = parse parseModuleRename "./test/data/module-rename-single.diff" inRuleText
   rule <-

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,7 +6,7 @@ import Language.PureScript.CST.Parser (parseModule)
 import Data.CSTRewrite (rewrite)
 
 main :: IO ()
-main = print "you should write some tests"
+main = testImportRewrite
 
 testImportRewrite :: IO ()
 testImportRewrite = do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,18 @@
 module Main where
 
+import qualified Data.Text.IO as T
+import qualified Language.PureScript.CST.Lexer as PS
+import Language.PureScript.CST.Parser (parseModule)
+import Data.CSTRewrite (rewrite)
+
 main :: IO ()
-main = print "You should write some tests 🍝"
+main = testImportRewrite
+
+testImportRewrite :: IO ()
+testImportRewrite = do
+    inText <- T.readFile "./data/example.purs"
+    let lexed = PS.lex inText
+    let parsed = parseModule lexed
+    either (\_ -> print "no good") (\m -> const (print "great") (rewrite rules <$> m)) parsed
+    where
+        rules = undefined

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -44,10 +44,10 @@ testImportRewrite = do
       (\_ -> fail "couldn't parse example PureScript module -- ensure it is valid PureScript")
       ( \m ->
           let partial = PS.resPartial m
-              rewritten = rewrite (Rules [] [rule]) partial
+              rewritten = rewrite (Rules [rule]) partial
               moduleNames = (PS.nameValue . PS.impModule) <$> PS.modImports rewritten
            in do
-                _ <- moduleNames `shouldContain` ([toModuleName rule])
+                moduleNames `shouldContain` ([toModuleName rule])
                 moduleNames `shouldNotContain` ([fromModuleName rule])
       )
       parsedModule

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,18 +1,47 @@
 module Main where
 
-import qualified Data.Text.IO as T
-import qualified Language.PureScript.CST.Lexer as PS
-import Language.PureScript.CST.Parser (parseModule)
 import Data.CSTRewrite (rewrite)
+import Data.CSTRewrite.Parser (parseModuleRename)
+import Data.CSTRewrite.Rule (Rules (Rules))
+import qualified Data.Text.IO as T
+import GHC.IO.Exception (ExitCode (..))
+import qualified Language.PureScript.CST.Lexer as PS
+import qualified Language.PureScript.CST.Parser as PS
+import qualified Language.PureScript.CST.Print as PS
+import System.Exit (exitWith)
+import Text.Parsec (parse)
 
 main :: IO ()
-main = testImportRewrite
+main = do
+  ruleParseTest <- testRuleParser
+  rewriteTest <- testImportRewrite
+  exitWith (maximum [ruleParseTest, rewriteTest])
 
-testImportRewrite :: IO ()
+testImportRewrite :: IO ExitCode
 testImportRewrite = do
-    inText <- T.readFile "./data/example.purs"
-    let lexed = PS.lex inText
-    let parsed = parseModule lexed
-    either (\_ -> print "no good") (\m -> const (print "great") (rewrite rules <$> m)) parsed
-    where
-        rules = undefined
+  inModuleText <- T.readFile "./test/data/example.purs"
+  let lexed = PS.lex inModuleText
+  let parsedModule = PS.parseModule lexed
+  print . show $ PS.resPartial <$> parsedModule
+  inRuleText <- T.readFile "./test/data/module-rename-single.diff"
+  let parsedRule = parse parseModuleRename "./test/data/module-rename-single.diff" inRuleText
+  rules <-
+    either
+      (\_ -> print "can't parse rule" *> exitWith (ExitFailure 1))
+      ( \rule ->
+          pure $ Rules [] [rule]
+      )
+      parsedRule
+  either
+    (\_ -> print "couldn't parse module" *> (pure $ ExitFailure 1))
+    (\m -> ExitSuccess <$ (print . show $ PS.resPartial (rewrite rules <$> m)))
+    parsedModule
+
+testRuleParser :: IO ExitCode
+testRuleParser = do
+  inRuleText <- T.readFile "./test/data/module-rename-single.diff"
+  let parsedRule = parse parseModuleRename "./test/data/module-rename-single.diff" inRuleText
+  either
+    (\err -> ExitFailure 1 <$ (print $ show err))
+    (\_ -> pure ExitSuccess)
+    parsedRule

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,7 +6,7 @@ import Language.PureScript.CST.Parser (parseModule)
 import Data.CSTRewrite (rewrite)
 
 main :: IO ()
-main = testImportRewrite
+main = print "you should write some tests"
 
 testImportRewrite :: IO ()
 testImportRewrite = do

--- a/test/data/module-rename-single.diff
+++ b/test/data/module-rename-single.diff
@@ -1,0 +1,5 @@
+# module rename
+--- from
+-import Foo
++++ to
++import Foo.Lib


### PR DESCRIPTION
Overview
-----

This PR adds (someday will add) a simple import rewriter. The import rewriter won't ensure that the resulting code compiles, but it will at change module names in imports, after which users can rely on the PureScript compiler to point them to what else they need to do.