### PR TITLE
Error when rules contain unexpected extra data

### DIFF
--- a/purescript-cst-rewrite.cabal
+++ b/purescript-cst-rewrite.cabal
@@ -21,6 +21,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , purescript-ast
                      , purescript-cst
+                     , containers
                      , parsec
                      , text
   default-language:    Haskell2010


### PR DESCRIPTION
Overview
-----

This PR ensures that parsing fails when rule lines contain unexpected extra input.

For example, `import Foo\\\\\\\\o` is not valid PureScript input. Neither is `import Foo hey bud how's it going`. However, in both cases prior to this PR, the parser was happy with the result because it could get an import declaration from the beginning and pass
the parser state off for downstream consumption. I didn't have any downstream consumption before, so the program continued as
if everything was fine.

Now, instead, when parsing fails to consume all the input in a rule line up to EOF, the program bails before it starts rewriting files.

Testing
-----

- add some garbage to the example rule in `test/data/` to make it invalid purescript
- try to run the example command from the README
- it should fail and give you a more or less kind of helpful error